### PR TITLE
Move scm plugin config to pluginManagement so it can be used by child projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+- oraclejdk8
+script:
+- "mvn install"

--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,20 @@
                         </excludes>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-scm-publish-plugin</artifactId>
+                    <version>1.1</version>
+                    <inherited>false</inherited>
+                    <configuration>
+                        <checkinComment>Publishing javadoc for ${project.artifactId}:${project.version}</checkinComment>
+                        <content>${gh-pages.dir}</content>
+                        <skipDeletedFiles>true</skipDeletedFiles>
+                        <pubScmUrl>scm:git:https://${github.api.key}@github.com/${github.slug}.git</pubScmUrl>
+                        <scmBranch>gh-pages</scmBranch> <!-- branch with static site -->
+                        <checkoutDirectory>${project.build.directory}/scmpublish-checkout-javadoc</checkoutDirectory>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -617,12 +631,27 @@
                 <javadoc.output.dir>${gh-pages.dir}/${javadoc.version.dir}apidocs</javadoc.output.dir>
             </properties>
             <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <top><![CDATA[
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-scm-publish-plugin</artifactId>
+                            <version>1.1</version>
+                            <inherited>false</inherited>
+                            <configuration>
+                                <checkinComment>Publishing javadoc for ${project.artifactId}:${project.version}</checkinComment>
+                                <content>${gh-pages.dir}</content>
+                                <skipDeletedFiles>true</skipDeletedFiles>
+                                <pubScmUrl>scm:git:https://${github.api.key}@github.com/${github.slug}.git</pubScmUrl>
+                                <scmBranch>gh-pages</scmBranch> <!-- branch with static site -->
+                                <checkoutDirectory>${project.build.directory}/scmpublish-checkout-javadoc</checkoutDirectory>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <top><![CDATA[
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -632,31 +661,30 @@
       ga('send', 'pageview');
     </script>
                                 ]]></top>
-                            <additionalparam>--allow-script-in-comments</additionalparam>
-                            <excludePackageNames>
-                                *com.okta.sdk.impl.*:
-                                *com.okta.swagger.*:
-                                *.examples:
-                                *.tutorial.*:
-                                *quickstart
-                            </excludePackageNames>
-                            <outputDirectory>${javadoc.output.dir}</outputDirectory>
-                            <reportOutputDirectory>${javadoc.output.dir}</reportOutputDirectory>
-                        </configuration>
+                                <additionalparam>--allow-script-in-comments</additionalparam>
+                                <excludePackageNames>
+                                    *com.okta.sdk.impl.*:
+                                    *com.okta.swagger.*:
+                                    *.examples:
+                                    *.tutorial.*:
+                                    *quickstart
+                                </excludePackageNames>
+                                <outputDirectory>${javadoc.output.dir}</outputDirectory>
+                                <reportOutputDirectory>${javadoc.output.dir}</reportOutputDirectory>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-scm-publish-plugin</artifactId>
                         <version>1.1</version>
                         <inherited>false</inherited>
-                        <configuration>
-                            <checkinComment>Publishing javadoc for ${project.artifactId}:${project.version}</checkinComment>
-                            <content>${gh-pages.dir}</content>
-                            <skipDeletedFiles>true</skipDeletedFiles>
-                            <pubScmUrl>scm:git:https://${github.api.key}@github.com/${github.slug}.git</pubScmUrl>
-                            <scmBranch>gh-pages</scmBranch> <!-- branch with static site -->
-                            <checkoutDirectory>${project.build.directory}/scmpublish-checkout-javadoc</checkoutDirectory>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
(this originally came from the okta/okta-sdk-java project, which would not of had this inheritance issue

NOTE: I'm going to cut another release after this is merged (so I can get a few other projects building on travis)
