### PR TITLE
Update build dependencies to support building and testing with Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: java
+
 jdk:
 - oraclejdk8
-addons:
+- openjdk11
+
+-addons:
   apt:
     packages:
     - libxml2-utils
     - oracle-java8-installer
     - oracle-java8-set-default
+
+# skip the Travis-CI install phase because Maven handles that directly
 install:
 - "true"
+
 script:
 - "./mvnw install"

--- a/build-support/src/main/resources/license/mapping.xml
+++ b/build-support/src/main/resources/license/mapping.xml
@@ -13,7 +13,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<license-lookup xsi:schemaLocation="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup https://source.jasig.org/schemas/maven-notice-plugin/license-lookup/license-lookup-v1.0.xsd" xmlns="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<license-lookup>
     <script/>
     <artifact>
         <groupId>classworlds</groupId>

--- a/doclist-plugin/src/main/java/com/okta/maven/doclist/DocListMojo.java
+++ b/doclist-plugin/src/main/java/com/okta/maven/doclist/DocListMojo.java
@@ -79,10 +79,10 @@ public class DocListMojo extends AbstractMojo {
             outputDirectory.mkdirs();
 
             // copy in image
-            String imageName = "okta-dev-logo-48.png";
-            File imageDest = new File(outputDirectory, "images/" + imageName);
+            String imageName = "/images/okta-dev-logo-48.png";
+            File imageDest = new File(outputDirectory, imageName);
             imageDest.getParentFile().mkdir();
-            FileUtils.copyURLToFile(getClass().getResource("/images/" + imageName), imageDest);
+            FileUtils.copyURLToFile(DocListMojo.class.getResource(imageName), imageDest);
 
             // figure out the current version
             NavigableMap<String, String> versionsMap = new TreeMap<>(getVersions().stream()

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -36,11 +36,11 @@
         <maven.compiler.source>${jdk.version}</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.25</slf4j.version>
-        <testng.version>6.9.10</testng.version>
+        <testng.version>6.14.3</testng.version>
         <maven.version>3.6.0</maven.version>
 
         <!-- Test Dependencies: Only required for testing when building the SDK.  Not required by SDK users at runtime: -->
-        <groovy.version>2.5.2</groovy.version>
+        <groovy.version>2.5.5</groovy.version>
 
         <!-- deploy site key -->
         <github.api.key>${env.GH_API_KEY}</github.api.key>
@@ -102,7 +102,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.7.22</version>
+                <version>2.23.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -198,12 +198,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.22.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.22.1</version>
                 <configuration>
                     <includes>
                         <include>**/*IT.java</include>
@@ -273,7 +273,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>
@@ -304,13 +304,13 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.9</version>
+                    <version>0.8.3</version>
                 </plugin>
                 <!-- FindBugs Static Analysis -->
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>3.0.4</version>
+                    <version>3.0.5</version>
                     <configuration>
                         <effort>Max</effort>
                         <threshold>Low</threshold>
@@ -394,6 +394,21 @@
                             <groupId>com.okta</groupId>
                             <artifactId>okta-parent-build-support</artifactId>
                             <version>11-SNAPSHOT</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>javax.xml.bind</groupId>
+                            <artifactId>jaxb-api</artifactId>
+                            <version>2.3.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.sun.xml.bind</groupId>
+                            <artifactId>jaxb-impl</artifactId>
+                            <version>2.3.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.sun.istack</groupId>
+                            <artifactId>istack-commons-runtime</artifactId>
+                            <version>3.0.8</version>
                         </dependency>
                     </dependencies>
                     <configuration>


### PR DESCRIPTION
- Updated travis config to build with oracle jdk 8 and open jdk 11
- removed the xsd from mapping.xml as looking up the xsd causes problem with some implementations (and validation is NOT needed at build time)
- Findbugs found an false positive in DocListMojo, but it was easier to cleanup the code than exclude
- TONS of build related version updates to support both 8 and 11