### PR TITLE
Work around the notice-plugin not working with JDK 11

### DIFF
--- a/build-support/src/main/resources/license/mapping.xml
+++ b/build-support/src/main/resources/license/mapping.xml
@@ -13,8 +13,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<license-lookup>
-    <script/>
+<license-lookup xmlns="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup https://source.jasig.org/schemas/maven-notice-plugin/license-lookup/license-lookup-v1.0.xsd">
+
     <artifact>
         <groupId>classworlds</groupId>
         <artifactId>classworlds</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -395,21 +395,6 @@
                             <artifactId>okta-parent-build-support</artifactId>
                             <version>12-SNAPSHOT</version>
                         </dependency>
-                        <dependency>
-                            <groupId>javax.xml.bind</groupId>
-                            <artifactId>jaxb-api</artifactId>
-                            <version>2.3.1</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.sun.xml.bind</groupId>
-                            <artifactId>jaxb-impl</artifactId>
-                            <version>2.3.1</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.sun.istack</groupId>
-                            <artifactId>istack-commons-runtime</artifactId>
-                            <version>3.0.8</version>
-                        </dependency>
                     </dependencies>
                     <configuration>
                         <fileName>THIRD-PARTY-NOTICES</fileName>
@@ -426,6 +411,47 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>other-jdk</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jasig.maven</groupId>
+                            <artifactId>maven-notice-plugin</artifactId>
+                            <configuration>
+                                <skipChecks>true</skipChecks>
+                            </configuration>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>javax.xml.bind</groupId>
+                                    <artifactId>jaxb-api</artifactId>
+                                    <version>2.1</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>com.sun.xml.bind</groupId>
+                                    <artifactId>jaxb-core</artifactId>
+                                    <version>2.1.14</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>com.sun.xml.bind</groupId>
+                                    <artifactId>jaxb-impl</artifactId>
+                                    <version>2.1.14</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>com.sun.activation</groupId>
+                                    <artifactId>jakarta.activation</artifactId>
+                                    <version>1.2.1</version>
+                                </dependency>
+                            </dependencies>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
         <profile>
             <id>docs</id>
             <build>


### PR DESCRIPTION
I tried a bunch of jaxb work arounds, but came up with skipping that plugin when running on JDK 11
Because of this, the xmlns change is reverted from the previous commit