### PR TITLE
Fix issue where CodeSnippetMojo strips out to much whitespace

### DIFF
--- a/code-snippet-plugin/src/main/java/com/okta/maven/snippet/CodeSnippetMojo.java
+++ b/code-snippet-plugin/src/main/java/com/okta/maven/snippet/CodeSnippetMojo.java
@@ -133,7 +133,7 @@ public class CodeSnippetMojo extends AbstractMojo {
                                 blockAsString.append("\n")
                                             .append(comment.get());
                             }
-                            blockAsString.append(tokenRange.toString().replaceAll(" {8}", ""));
+                            blockAsString.append(tokenRange.toString().replaceAll("\n {8}", "\n"));
 
                             return blockAsString;
                         })

--- a/code-snippet-plugin/src/test/java/com/okta/maven/snippet/Example.java
+++ b/code-snippet-plugin/src/test/java/com/okta/maven/snippet/Example.java
@@ -23,6 +23,13 @@ public class Example {
         int result = 1 + 1;
     }
 
+    public void lotsOfWhiteSpace() {
+        System
+                .out
+                .println("doing foo");
+        int result =   1 + 1;
+    }
+
     private void andBar(String value) {
         // with a comment
         String another = value + "bar";

--- a/code-snippet-plugin/src/test/resources/README-expected.md
+++ b/code-snippet-plugin/src/test/resources/README-expected.md
@@ -20,3 +20,14 @@ String another = value + "bar";
 int result = 2 + 2;
 ```
 [//]: # (end: andBar)
+
+Lots of whitespace
+
+[//]: # (method: lotsOfWhiteSpace)
+```java
+System
+        .out
+        .println("doing foo");
+int result =   1 + 1;
+```
+[//]: # (end: lotsOfWhiteSpace)

--- a/code-snippet-plugin/src/test/resources/README.md
+++ b/code-snippet-plugin/src/test/resources/README.md
@@ -9,3 +9,8 @@ Another example:
 
 [//]: # (method: andBar)
 [//]: # (end: andBar)
+
+Lots of whitespace
+
+[//]: # (method: lotsOfWhiteSpace)
+[//]: # (end: lotsOfWhiteSpace)


### PR DESCRIPTION
blindly striping out groups of 8 spaces caused formatting issues when displaying nested code blocks