### PR TITLE
groovy 4 java 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: java
 jdk:
 - openjdk8
 - openjdk11
+- openjdk17
 
 -addons:
   apt:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -213,12 +213,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
-                <configuration>
-                    <!-- Groovy tests access private fields -->
-                    <argLine>
-                        --add-opens=java.base/java.util=ALL-UNNAMED
-                    </argLine>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -479,6 +473,16 @@
                                     <version>2.0.1</version>
                                 </dependency>
                             </dependencies>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <!-- Groovy tests access private fields -->
+                                <argLine>
+                                    --add-opens=java.base/java.util=ALL-UNNAMED
+                                </argLine>
+                            </configuration>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -440,7 +440,7 @@
         <profile>
             <id>other-jdk</id>
             <activation>
-                <jdk>11</jdk>
+                <jdk>[11,)</jdk>
             </activation>
             <build>
                 <pluginManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -40,7 +40,7 @@
         <maven.version>3.8.1</maven.version>
 
         <!-- Test Dependencies: Only required for testing when building the SDK.  Not required by SDK users at runtime: -->
-        <groovy.version>3.0.9</groovy.version>
+        <groovy.version>4.0.0</groovy.version>
 
         <!-- deploy site key -->
         <github.api.key>${env.GH_API_KEY}</github.api.key>
@@ -85,19 +85,19 @@
 
             <!-- test deps -->
             <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy</artifactId>
                 <version>${groovy.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-templates</artifactId>
                 <version>${groovy.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-json</artifactId>
                 <version>${groovy.version}</version>
                 <scope>test</scope>
@@ -132,17 +132,17 @@
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-templates</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-json</artifactId>
             <scope>test</scope>
         </dependency>
@@ -189,7 +189,7 @@
                 <version>1.8.0</version>
                 <dependencies>
                     <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
+                        <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy</artifactId>
                         <version>${groovy.version}</version>
                     </dependency>
@@ -213,6 +213,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <!-- Groovy tests access private fields -->
+                    <argLine>
+                        --add-opens=java.base/java.util=ALL-UNNAMED
+                    </argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- Use range syntax instead of hard coding to java 11
- Update to Groovy 4 to support Java 17 builds
