### PR TITLE
Fix code jacoco coverage report

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -480,7 +480,7 @@
                             <configuration>
                                 <!-- Groovy tests access private fields -->
                                 <argLine>
-                                    --add-opens=java.base/java.util=ALL-UNNAMED
+                                    @{argLine} --add-opens=java.base/java.util=ALL-UNNAMED
                                 </argLine>
                             </configuration>
                         </plugin>


### PR DESCRIPTION
The direct setting of surefire's 'argLine' overrides the jacoco argLine. This explicitly sets the arg.
