### PR TITLE
Revert `org.jasig.maven:maven-notice-plugin` from 2.0.0 to 1.1.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -409,7 +409,7 @@
                 <plugin>
                     <groupId>org.jasig.maven</groupId>
                     <artifactId>maven-notice-plugin</artifactId>
-                    <version>2.0.0</version>
+                    <version>1.1.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.okta</groupId>


### PR DESCRIPTION
https://github.com/Jasig/maven-notice-plugin/issues/24