### PR TITLE
Bump `org.eclipse.jgit` dependency version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,14 +14,14 @@ jobs:
 
   jdk11:
     docker:
-      - image: cimg/openjdk:11.0.13
+      - image: cimg/openjdk:11.0.20
     environment:
         JVM_OPTS: -Xmx3200m
     steps: *build_steps
 
   jdk17:
     docker:
-      - image: cimg/openjdk:17.0.4
+      - image: cimg/openjdk:17.0.8
     environment:
         JVM_OPTS: -Xmx3200m
     steps: *build_steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,20 +26,11 @@ jobs:
         JVM_OPTS: -Xmx3200m
     steps: *build_steps
 
-  jdk21:
-    docker:
-      - image: cimg/openjdk:21.0.0
-    environment:
-      JVM_OPTS: -Xmx3200m
-    steps: *build_steps
-
 workflows:
   build_and_test:
     jobs:
       - jdk11
       - jdk17
-      - jdk21
-  # See OKTA-634408
   semgrep:
     jobs:
       - general-platform-helpers/job-semgrep-prepare:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,6 @@ aliases:
 
 jobs:
 
-  jdk8:
-    docker:
-      - image: cimg/openjdk:8.0.322
-    environment:
-        JVM_OPTS: -Xmx3200m
-    steps: *build_steps
-
   jdk11:
     docker:
       - image: cimg/openjdk:11.0.13
@@ -33,12 +26,19 @@ jobs:
         JVM_OPTS: -Xmx3200m
     steps: *build_steps
 
+  jdk21:
+    docker:
+      - image: cimg/openjdk:21.0.0
+    environment:
+      JVM_OPTS: -Xmx3200m
+    steps: *build_steps
+
 workflows:
   build_and_test:
     jobs:
-      - jdk8
       - jdk11
       - jdk17
+      - jdk21
   # See OKTA-634408
   semgrep:
     jobs:

--- a/doclist-plugin/pom.xml
+++ b/doclist-plugin/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.8.0.202006091008-r</version>
+            <version>6.6.1.202309021850-r</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
- Bump `org.eclipse.jgit` from `5.8.0.202006091008-r` to `6.6.1.202309021850-r` (to fix cve, see OKTA-650081)
- Remove jdk8 from CCI builds (since the above eclipse dependency upgrade is not supported in jdk8).