### PR TITLE
Suppress CVE false positives

### DIFF
--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -19,5 +19,11 @@
   -->
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
+<!-- False positive - https://github.com/jeremylong/DependencyCheck/issues/5973 -->
+<suppress>
+   <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-(cipher|classworlds|component-annotations|interpolation|sec-dispatcher|xml)@.*$</packageUrl>
+   <cve>CVE-2022-4244</cve>
+   <cve>CVE-2022-4245</cve>
+</suppress>
 
 </suppressions>


### PR DESCRIPTION
The following CVEs are reported by the [dependency check tool](https://github.com/jeremylong/DependencyCheck) and these are false positives that should be suppressed. 

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.315 s
[INFO] Finished at: 2024-06-25T13:01:18-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:9.2.0:aggregate (default-cli) on project okta-aggregator:
[ERROR]
[ERROR] One or more dependencies were identified with vulnerabilities:
[ERROR]
[ERROR] plexus-cipher-2.0.jar: CVE-2022-4245(4.3), CVE-2022-4244(7.5)
[ERROR] plexus-classworlds-2.8.0.jar: CVE-2022-4245(4.3), CVE-2022-4244(7.5)
[ERROR] plexus-component-annotations-2.1.0.jar: CVE-2022-4245(4.3), CVE-2022-4244(7.5)
[ERROR] plexus-interpolation-1.27.jar: CVE-2022-4245(4.3), CVE-2022-4244(7.5)
[ERROR] plexus-sec-dispatcher-2.0.jar: CVE-2022-4245(4.3), CVE-2022-4244(7.5)
[ERROR] plexus-xml-3.0.0.jar: CVE-2022-4245(4.3), CVE-2022-4244(7.5)
[ERROR]
[ERROR] See the dependency-check report for more details.
[ERROR]
[ERROR]
[ERROR] -> [Help 1]
```

Ref: https://github.com/jeremylong/DependencyCheck/issues/5973