### PR TITLE
Added NVD API Key and replaced deprecated `failBuildOnAnyVulnerability` plugin parameter #457

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,9 @@
                     <version>10.0.1</version>
                     <configuration>
                         <suppressionFile>${root.dir}/src/owasp/owasp-suppression.xml</suppressionFile>
-                        <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+                        <failBuildOnCVSS>0</failBuildOnCVSS>
                         <name>OWASP Dependency Check</name>
+                        <nvdApiKey>${nvd.api.key}</nvdApiKey>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
- Added NVD API Key to `dependency-check-maven` plugin.
- Replaced deprecated parameter `failBuildOnAnyVulnerability` with `failBuildOnCVSS` parameter (Ref: https://jeremylong.github.io/DependencyCheck/dependency-check-maven/check-mojo.html).

