### PR TITLE
Upgrade commons-lang3 to 3.18.0 to address security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,17 @@
         <module>code-snippet-plugin</module>
     </modules>
 
+    <!-- Added dependencyManagement to fix commons-lang3 version -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.18.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
This PR upgrades the version of commons-lang3 to 3.18.0 via dependencyManagement in the parent POM.  
This fixes the known security vulnerability (CVE-2025-48924) detected by Snyk in version 3.17.0.  

No other dependencies or functionality should be impacted.  
